### PR TITLE
Character encoding fix (other than utf-8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Several options are available using the command line:
                             The path to the to the destination file: .html or .pdf
                             extensions allowed (default: presentation.html)
       -e ENCODING, --encoding=ENCODING
-                            The encoding of your files (defaults to utf8)
+                            The encoding of your files (defaults to utf-8)
       -i, --embed           Embed base64-encoded images in presentation
       -t THEME, --theme=THEME
                             A theme name, or path to a landlside theme directory
@@ -314,6 +314,7 @@ The `base.html` must be a [Jinja2 template file](http://jinja.pocoo.org/2/docume
   - `content`: the slide contents
   - `number`: the slide number
 - `embed`: is the current document a standalone one?
+- `encoding`: document character encoding
 - `num_slides`: the number of slides in current presentation
 - `toc`: the Table of Contents, listing sections of the document. Each section has these properties available:
   - `title`: the section title

--- a/src/landslide/generator.py
+++ b/src/landslide/generator.py
@@ -37,7 +37,7 @@ TOC_MAX_LEVEL = 2
 class Generator(object):
     def __init__(self, source, destination_file='presentation.html',
                  theme='default', direct=False, debug=False, verbose=True,
-                 embed=False, encoding='utf8', logger=None):
+                 embed=False, encoding='utf-8', logger=None):
         """Configures this generator from its properties."""
         self.debug = debug
         self.direct = direct
@@ -285,7 +285,8 @@ class Generator(object):
 
         return {'head_title': head_title, 'num_slides': str(self.num_slides),
                 'slides': slides, 'toc': self.toc, 'embed': self.embed,
-                'css': self.get_css(), 'js': self.get_js()}
+                'css': self.get_css(), 'js': self.get_js(),
+                'encoding': self.encoding}
 
     def log(self, message, type='notice'):
         """Log a message (eventually, override to do something more clever)"""

--- a/src/landslide/main.py
+++ b/src/landslide/main.py
@@ -55,9 +55,9 @@ def _parse_options():
     parser.add_option(
         "-e", "--encoding",
         dest="encoding",
-        help="The encoding of your files (defaults to utf8)",
+        help="The encoding of your files (defaults to utf-8)",
         metavar="ENCODING",
-        default="utf8"
+        default="utf-8"
     )
 
     parser.add_option(

--- a/src/landslide/parser.py
+++ b/src/landslide/parser.py
@@ -23,7 +23,7 @@ SUPPORTED_FORMATS = {
 
 
 class Parser(object):
-    def __init__(self, extension, encoding='utf8'):
+    def __init__(self, extension, encoding='utf-8'):
         """Configures this parser"""
         self.encoding = encoding
         self.format = None

--- a/src/landslide/themes/default/base.html
+++ b/src/landslide/themes/default/base.html
@@ -23,7 +23,7 @@
 -->
 <html>
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset={{ encoding }}" />
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <title>{{ head_title }}</title>
     <!-- Styles -->


### PR DESCRIPTION
I was using the 0.8.1 release when I encountered the utf8 problem. Found the fix here, great! When I tested with an iso-8859-1 file, I noticed base.html hard-coded utf-8. I changed all instances of "utf8" to "utf-8" and now I'm passing the encoding to the html template as well.

I didn't try generating PDF though.
