### PR TITLE
Add option -x to specify extensions for Markdown.

### DIFF
--- a/src/landslide/generator.py
+++ b/src/landslide/generator.py
@@ -37,13 +37,14 @@ TOC_MAX_LEVEL = 2
 class Generator(object):
     def __init__(self, source, destination_file='presentation.html',
                  theme='default', direct=False, debug=False, verbose=True,
-                 embed=False, encoding='utf8', logger=None):
+                 embed=False, encoding='utf8', logger=None, extensions=''):
         """Configures this generator from its properties."""
         self.debug = debug
         self.direct = direct
         self.encoding = encoding
         self.logger = None
         self.num_slides = 0
+        self.extensions = extensions
         self.__toc = []
 
         # macros registering
@@ -179,7 +180,7 @@ class Generator(object):
                 slides.extend(self.fetch_contents(os.path.join(source, entry)))
         else:
             try:
-                parser = Parser(os.path.splitext(source)[1], self.encoding)
+                parser = Parser(os.path.splitext(source)[1], self.encoding, self.extensions)
             except NotImplementedError:
                 return slides
 

--- a/src/landslide/main.py
+++ b/src/landslide/main.py
@@ -103,6 +103,13 @@ def _parse_options():
         default=True
     )
 
+    parser.add_option(
+        "-x", "--extensions",
+        dest="extensions",
+        help="Comma-separated list of extensions for Markdown",
+        default=''
+    )
+
     (options, args) = parser.parse_args()
 
     if not args:
@@ -121,7 +128,7 @@ def run(input_file, options):
                           options.theme, direct=options.direct,
                           debug=options.debug, verbose=options.verbose,
                           embed=options.embed, encoding=options.encoding,
-                          logger=log)
+                          logger=log, extensions=options.extensions)
     generator.execute()
 
 

--- a/src/landslide/parser.py
+++ b/src/landslide/parser.py
@@ -28,7 +28,7 @@ class Parser(object):
     
     The Parser currently supports both Markdown and restructuredText syntaxes.
     """
-    def __init__(self, extension, encoding='utf8'):
+    def __init__(self, extension, encoding='utf8', extensions=''):
         """Configures this parser"""
         self.encoding = encoding
         self.format = None
@@ -39,6 +39,8 @@ class Parser(object):
         if not self.format:
             raise NotImplementedError(u"Unsupported format %s" % extension)
 
+        self.extensions = filter(None, (value.strip() for value in extensions.split(',')))
+
     def parse(self, text):
         """Parses and renders a text as HTML regarding current format."""
         if self.format == 'markdown':
@@ -47,7 +49,7 @@ class Parser(object):
             except ImportError:
                 raise RuntimeError(u"Looks like markdown is not installed")
 
-            return markdown.markdown(text)
+            return markdown.markdown(text, self.extensions)
         elif self.format == 'restructuredtext':
             try:
                 from rst import html_parts, html_body


### PR DESCRIPTION
This is useful, if you want to use tables (or other extensions from http://www.freewisdom.org/projects/python-markdown/Available_Extensions) in a presentation.
