### PR TITLE
Fix font fallback in themes' CSS

### DIFF
--- a/src/landslide/themes/default/css/screen.css
+++ b/src/landslide/themes/default/css/screen.css
@@ -199,7 +199,7 @@ body.presenter_view div#current_presenter_notes {
 }
 
 body.presenter_view div#current_presenter_notes section {
-  font-family: 'Lucida Grande';
+  font-family: "Lucida Grande", "Trebuchet MS", Verdana, sans-serif;
   color: black;
   text-shadow: rgba(0, 0, 0, 0.2) 0 2px 5px;
   display: block;
@@ -273,7 +273,7 @@ body.three-d div.slides {
 /* Content */
 
 header:not(:only-child) {
-  font-family: 'Lucida Grande';
+  font-family: "Lucida Grande", "Trebuchet MS", Verdana, sans-serif;
   font-weight: normal;
   font-size: 50px;
   letter-spacing: -.05em;
@@ -299,7 +299,7 @@ header h2:first-child {
 }
 
 section, .slide header:only-child h1 {
-  font-family: 'Lucida Grande';
+  font-family: "Lucida Grande", "Trebuchet MS", Verdana, sans-serif;
   color: #3f3f3f;
   text-shadow: rgba(0, 0, 0, 0.2) 0 2px 5px;
   margin-left: 30px;

--- a/src/landslide/themes/light/css/screen.css
+++ b/src/landslide/themes/light/css/screen.css
@@ -104,7 +104,7 @@ body.three-d div.slides {
 /* Content */
 
 header:not(:only-child) {
-  font-family: 'Lucida Grande';
+  font-family: "Lucida Grande", "Trebuchet MS", Verdana, sans-serif;
   font-weight: normal;
   font-size: 50px;
   letter-spacing: -.05em;
@@ -131,7 +131,7 @@ header h2:first-child {
 }
 
 section, .slide header:only-child h1 {
-  font-family: 'Lucida Grande';
+  font-family: "Lucida Grande", "Trebuchet MS", Verdana, sans-serif;
   color: #3f3f3f;
   text-shadow: rgba(0, 0, 0, 0.2) 0 2px 5px;
   margin-left: 30px;
@@ -466,7 +466,7 @@ body.presenter_view div#current_presenter_notes {
 }
 
 body.presenter_view div#current_presenter_notes section {
-  font-family: 'Lucida Grande';
+  font-family: "Lucida Grande", "Trebuchet MS", Verdana, sans-serif;
   color: black;
   text-shadow: rgba(0, 0, 0, 0.2) 0 2px 5px;
   display: block;

--- a/src/landslide/themes/tango/css/screen.css
+++ b/src/landslide/themes/tango/css/screen.css
@@ -125,7 +125,7 @@ body.three-d div.slides {
 /* Content */
 
 header:not(:only-child) {
-  font-family: 'Lucida Grande';
+  font-family: "Lucida Grande", "Trebuchet MS", Verdana, sans-serif;
   font-weight: normal;
   font-size: 50px;
   letter-spacing: -.05em;
@@ -152,7 +152,7 @@ header h2:first-child {
 }
 
 section, .slide header:only-child h1 {
-  font-family: 'Lucida Grande';
+  font-family: "Lucida Grande", "Trebuchet MS", Verdana, sans-serif;
   color: #3f3f3f;
   text-shadow: rgba(0, 0, 0, 0.2) 0 2px 5px;
   margin-left: 30px;
@@ -482,7 +482,7 @@ body.presenter_view div#current_presenter_notes {
 }
 
 body.presenter_view div#current_presenter_notes section {
-  font-family: 'Lucida Grande';
+  font-family: "Lucida Grande", "Trebuchet MS", Verdana, sans-serif;
   color: black;
   text-shadow: rgba(0, 0, 0, 0.2) 0 2px 5px;
   display: block;


### PR DESCRIPTION
In theme CSS files, 'Lucida Grande' is used as a default font. Since it will not always be available, a font-family fallback had to be defined throughout the CSS.
