### PR TITLE
Run macros on headers, too, to embed images

### DIFF
--- a/src/landslide/generator.py
+++ b/src/landslide/generator.py
@@ -338,6 +338,9 @@ class Generator(object):
 
         slide_classes = []
 
+        if header:
+            header, _ = self.process_macros(header, source)
+
         if content:
             content, slide_classes = self.process_macros(content, source)
 


### PR DESCRIPTION
Sorry that I am not familiar with Python, so I'm not sure if this is a
correct fix. At least this works for me, I guess. The problem is that
I want to put images on headers, some because then it could be put on
the center of the slide, and some because I just want an image on
a header. I found that headers are skipped to be processed by macros,
so that images on headers aren't embedded. I am not sure if this is
designed to work this way, but it works for me... :)

Thank you for reading and considering!
