### PR TITLE
Fixed UnicodeEncodeError when used with --direct-ouput option.

### DIFF
--- a/src/landslide/generator.py
+++ b/src/landslide/generator.py
@@ -193,7 +193,7 @@ class Generator(object):
                 raise IOError(u"Direct output mode is not available for PDF "
                                "export")
             else:
-                print self.render()
+                print self.render().encode(self.encoding)
         else:
             self.write()
             self.log(u"Generated file: %s" % self.destination_file)


### PR DESCRIPTION
landslide was failing with UnicodeEncodeError when called with `--direct-ouput` option. Please accept this patch to fix it.
