### PR TITLE
Fixed error in CodeHighlightingMacro.

### DIFF
--- a/src/landslide/generator.py
+++ b/src/landslide/generator.py
@@ -193,7 +193,7 @@ class Generator(object):
                 raise IOError(u"Direct output mode is not available for PDF "
                                "export")
             else:
-                print self.render()
+                print self.render().encode(self.encoding)
         else:
             self.write()
             self.log(u"Generated file: %s" % self.destination_file)


### PR DESCRIPTION
The regular expression had a bug and matching multiple lines as part of `<pre.+?>`.

Here is a test to reproduce the bug:

```
from landslide.macro import CodeHighlightingMacro

content = """
<pre><code>Foo
</code></pre>

<pre><code>!python
Bar
</code></pre>
"""

m = CodeHighlightingMacro()
print m.process(content)[0]
assert 'Foo' in m.process(content)[0]
```
