### PR TITLE
Author display support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ The `base.html` must be a [Jinja2 template file](http://jinja.pocoo.org/2/docume
   - `title`: the section title
   - `number`: the slide number of the section
   - `sub`: subsections, if any
+- `author`: the author's information.
 
 # Styles Scope
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Or get it as a PDF document if PrinceXML is installed and available on your syst
 - Press `S` to toggle display of link to the source file for each slide
 - Press '2' to toggle notes in your slides (specify with the .notes macro)
 - Press '3' to toggle pseudo-3D display (experimental)
+- Press `a` to toggle display of the author name
 - Browser zooming is supported
 
 # Commandline Options

--- a/README.md
+++ b/README.md
@@ -152,6 +152,18 @@ Don't forget to declare the `[landslide]` section. To generate the presentation 
 
 You can use macros to enhance your presentation:
 
+## Author
+
+Set the presentation author by using the `.author:` keyword on the first slide, eg.:
+
+    # First slide's title
+
+    .author: I am the author
+
+    Other content goes here
+
+You can toggle display of the author by pressing the `a` key.
+
 ## Notes
 
 Add notes to your slides using the `.notes:` keyword, eg.:

--- a/src/landslide/generator.py
+++ b/src/landslide/generator.py
@@ -326,6 +326,7 @@ class Generator(object):
         find = re.search(r'(<h(\d+?).*?>(.+?)</h\d>)\s?(.+)?', slide_src,
                          re.DOTALL | re.UNICODE)
         presenter_notes = None
+        author = None
 
         if not find:
             header = level = title = None
@@ -348,6 +349,13 @@ class Generator(object):
                 presenter_notes = content[find.end():].strip()
                 content = content[:find.start()]
 
+            find = re.search(r'<p>\.author:\s?(.*?)</p>', content,
+                             re.DOTALL | re.UNICODE)
+
+            if find:
+                author = find.group(1)
+                content = re.sub(find.re, "", content, re.DOTALL | re.UNICODE)
+
         source_dict = {}
 
         if source:
@@ -357,7 +365,8 @@ class Generator(object):
         if header or content:
             return {'header': header, 'title': title, 'level': level,
                     'content': content, 'classes': slide_classes,
-                    'source': source_dict, 'presenter_notes': presenter_notes}
+                    'source': source_dict, 'presenter_notes': presenter_notes,
+                    'author': author}
 
     def get_template_vars(self, slides):
         """ Computes template vars from slides html source code.
@@ -366,6 +375,11 @@ class Generator(object):
             head_title = slides[0]['title']
         except (IndexError, TypeError):
             head_title = "Untitled Presentation"
+
+        try:
+            slides_author = slides[0]['author']
+        except (IndexError, TypeError):
+            slides_author = ""
 
         for slide_index, slide_vars in enumerate(slides):
             if not slide_vars:
@@ -379,7 +393,8 @@ class Generator(object):
         return {'head_title': head_title, 'num_slides': str(self.num_slides),
                 'slides': slides, 'toc': self.toc, 'embed': self.embed,
                 'css': self.get_css(), 'js': self.get_js(),
-                'user_css': self.user_css, 'user_js': self.user_js}
+                'user_css': self.user_css, 'user_js': self.user_js,
+                'author': slides_author}
 
     def linenos_check(self, value):
         """ Checks and returns a valid value for the ``linenos`` option.

--- a/src/landslide/themes/default/base.html
+++ b/src/landslide/themes/default/base.html
@@ -100,6 +100,9 @@
               Source: <a href="{{ slide.source.rel_path }}">{{ slide.source.rel_path }}</a>
             </aside>
             {% endif %}
+            <aside class="author">
+              {{ author }}
+            </aside>
             <aside class="page_number">
               {{ slide.number }}/{{ num_slides }}
             </aside>
@@ -150,6 +153,10 @@
       <tr>
         <th>Presenter View</th>
         <td>p</td>
+      </tr>
+      <tr>
+        <th>Author</th>
+        <td>a</td>
       </tr>
       <tr>
         <th>Source Files</th>

--- a/src/landslide/themes/default/css/screen.css
+++ b/src/landslide/themes/default/css/screen.css
@@ -445,6 +445,12 @@ aside {
     right: 10px;
     text-indent: 10px;
   }
+  aside.author {
+    position: absolute;
+    bottom: 22px;
+    left: 10px;
+    text-indent: 10px;
+  }
 
 .notes {
   display: none;

--- a/src/landslide/themes/default/js/slides.js
+++ b/src/landslide/themes/default/js/slides.js
@@ -216,6 +216,14 @@ function main() {
         updateOverview();
     };
 
+    var showSlideAuthor = function() {
+        var asides = document.getElementsByClassName('author');
+        var hidden = asides[0].style.display != 'block';
+        for (var i = 0; i < asides.length; i++) {
+            asides.item(i).style.display = hidden ? 'block' : 'none';
+        }
+    };
+
     var showHelp = function() {
         if (tocOpened) {
                 showToc();
@@ -454,6 +462,11 @@ function main() {
                 break;
             case 84: // t
                 showToc();
+                break;
+            case 65: // a
+                if (!modifierKeyDown && !overviewActive) {
+                    showSlideAuthor();
+                }
                 break;
         }
     };


### PR DESCRIPTION
I've added some logic to display an optional author in the slides footer. One simply adds a `.author: author name goes here` paragraph to the first slide. I've also made sure to remove the rendered paragraph, so the first slide remains a *title* slide if no other content was found.
To toggle display of the author's name (and/or info), the end-user simply presses `a`.