### PR TITLE
Add something to the TOC even if there's not a title on a slide

### DIFF
--- a/src/landslide/generator.py
+++ b/src/landslide/generator.py
@@ -375,6 +375,9 @@ class Generator(object):
             if slide_vars['level'] and slide_vars['level'] <= TOC_MAX_LEVEL:
                 self.add_toc_entry(slide_vars['title'], slide_vars['level'],
                                    slide_number)
+            else:
+                # Put something in the TOC even if it doesn't have a title or level
+                self.add_toc_entry(u"Untitled", 1, slide_number)
 
         return {'head_title': head_title, 'num_slides': str(self.num_slides),
                 'slides': slides, 'toc': self.toc, 'embed': self.embed,


### PR DESCRIPTION
The current code only adds an entry to the table of contents if there's a <h1> or <h2> tag - sometimes slides don't have titles, so add an entry to the TOC even if they're lacking a slide title.
