### PR TITLE
Include file macro

### DIFF
--- a/samples/example5/body.html
+++ b/samples/example5/body.html
@@ -1,0 +1,1 @@
+Supposed to be an HTML chunk (perhaps useful for title pages)

--- a/samples/example5/slides.md
+++ b/samples/example5/slides.md
@@ -1,0 +1,222 @@
+Macros to Include Files
+=======================
+
+---
+
+Syntax
+------
+
+- The basic argline syntax is simple: 1, 2, or 3 space-separated arguments.  The
+  first argument is always the file names.
+
+- The remainder are (optionally `/`-delimited patterns) or integer line numbers,
+  or "`$`" to represent the end of the file.
+
+        .{ code | coden | include }:   <file>   [ <pattern>   [<pattern>] ]
+
+    + `code`: include as a highlighted code block without linenos.
+
+    + `coden`: include as a highlighted code block with linenos.
+
+    + `include`: include the file as is.
+
+---
+
+Syntax
+------
+
+- Negative line numbers are allowed and works as expected, i.e. `-1` means the
+  last line and so on.
+
+- Patterns may optionally be succeeded with a signed offset spesification:
+  "`/pattern/+n`" for `n` lines downward after matched line, and "`/pattern/-n`"
+  for `n` lines upward before matched line.
+
+- Shortcut: In an offset specification, use "`+`" for "`+1`", and "`-`" for
+  "`-1`".
+
+---
+
+Gotchas
+-------
+
+- In patterns, no quotes and remember the args are blank-separated; so **you
+  might want to use "`.`" to represent a blank.**
+
+- Language is detected from the extension of the included file; so **make sure
+  to use the proper extension.**
+
+---
+
+
+Including as Code
+=================
+
+---
+
+Whole File
+----------
+
+Whole file with line numbers:
+
+        .coden: day.c
+
+.coden: day.c
+
+---
+
+One Line
+--------
+
+- 8th line
+
+        .code: day.c 8
+
+.code: day.c 8
+
+
+- Matched line
+
+        .code: day.c /.+wednesday/
+
+.code: day.c /.+wednesday/
+
+---
+
+One Line
+--------
+
+- Last line (two alternatives)
+
+        .code: day.c -1
+        .code: day.c $
+
+.code: day.c $
+
+- Third line from end
+
+        .code: day.c -3
+
+.code: day.c -3
+
+---
+
+Multi Lines
+-----------
+
+- Between numbered lines (inclusive)
+
+        .code: day.c 8 10
+
+.code: day.c 8 10
+
+
+- Between matched lines (inclusive)
+
+        .code: day.c /.+wednesday/ /.+friday/
+
+.code: day.c /.+wednesday/ /.+friday/
+
+---
+
+Multi Lines
+-----------
+
+- Matched line to end
+
+        .code: day.c /int/ $
+
+.code: day.c /int/ $
+
+---
+
+Multi Lines
+-----------
+
+
+- Last 5 lines
+
+        .code: day.c -5 $
+
+.code: day.c -5 $
+
+---
+
+Line Offsets
+------------
+
+- Matched lines with offsets
+
+        .code: day.c /main\(.+\)/- /}/
+
+.code: day.c /main\(.+\)/- /}/
+
+---
+
+Line Offsets
+------------
+
+
+- Matched lines with offsets
+
+        .code: day.c /static.const.char.+day/+2 /}/-
+
+.code: day.c /static.const.char.+day/+2 /}/-
+
+- Between matched lines (exclusive)
+
+        .code: day.c /.+wednesday/+ /.+friday/-
+
+.code: day.c /.+wednesday/+ /.+friday/-
+
+---
+
+Including as Raw
+================
+
+---
+
+Include Raw HTML
+----------------
+
+Include file as is:
+
+        .include: body.html
+
+.include: body.html
+
+---
+
+Options
+=======
+
+---
+
+Include Path
+------------
+
+- Include files are searched through each of the colon-separated directories in
+  "`includepath`" option.
+
+- The default value of "`includepath`" is as follows:
+
+        includepath=.:./src:./code:..:../src:../code
+
+- That means, you can put the file, e.g. "`day.c`", into the "`src`" or "`code`"
+  subdirectory, and later include it as "`.code: day.c`" (instead of "`.code:
+  src/day.c`").
+
+---
+
+Expanding Tabs
+--------------
+
+- Tabs in the include files are expanded to spaces (default is 8 spaces), which
+  work better in HTML.
+
+- You can change the default value for tabs expansion through the "`expandtabs`"
+  option.  For example:
+
+        expandtabs=4
+
+- Use 0 or a negative value for "`expandtabs`" to keep tabs.

--- a/samples/example5/slides.md
+++ b/samples/example5/slides.md
@@ -59,9 +59,9 @@ Whole File
 
 Whole file with line numbers:
 
-        .coden: day.c
+        .coden: src/day.c
 
-.coden: day.c
+.coden: src/day.c
 
 ---
 
@@ -70,16 +70,16 @@ One Line
 
 - 8th line
 
-        .code: day.c 8
+        .code: src/day.c 8
 
-.code: day.c 8
+.code: src/day.c 8
 
 
 - Matched line
 
-        .code: day.c /.+wednesday/
+        .code: src/day.c /.+wednesday/
 
-.code: day.c /.+wednesday/
+.code: src/day.c /.+wednesday/
 
 ---
 
@@ -88,16 +88,16 @@ One Line
 
 - Last line (two alternatives)
 
-        .code: day.c -1
-        .code: day.c $
+        .code: src/day.c -1
+        .code: src/day.c $
 
-.code: day.c $
+.code: src/day.c $
 
 - Third line from end
 
-        .code: day.c -3
+        .code: src/day.c -3
 
-.code: day.c -3
+.code: src/day.c -3
 
 ---
 
@@ -106,16 +106,16 @@ Multi Lines
 
 - Between numbered lines (inclusive)
 
-        .code: day.c 8 10
+        .code: src/day.c 8 10
 
-.code: day.c 8 10
+.code: src/day.c 8 10
 
 
 - Between matched lines (inclusive)
 
-        .code: day.c /.+wednesday/ /.+friday/
+        .code: src/day.c /.+wednesday/ /.+friday/
 
-.code: day.c /.+wednesday/ /.+friday/
+.code: src/day.c /.+wednesday/ /.+friday/
 
 ---
 
@@ -124,9 +124,9 @@ Multi Lines
 
 - Matched line to end
 
-        .code: day.c /int/ $
+        .code: src/day.c /int/ $
 
-.code: day.c /int/ $
+.code: src/day.c /int/ $
 
 ---
 
@@ -136,9 +136,9 @@ Multi Lines
 
 - Last 5 lines
 
-        .code: day.c -5 $
+        .code: src/day.c -5 $
 
-.code: day.c -5 $
+.code: src/day.c -5 $
 
 ---
 
@@ -147,9 +147,9 @@ Line Offsets
 
 - Matched lines with offsets
 
-        .code: day.c /main\(.+\)/- /}/
+        .code: src/day.c /main\(.+\)/- /}/
 
-.code: day.c /main\(.+\)/- /}/
+.code: src/day.c /main\(.+\)/- /}/
 
 ---
 
@@ -159,15 +159,15 @@ Line Offsets
 
 - Matched lines with offsets
 
-        .code: day.c /static.const.char.+day/+2 /}/-
+        .code: src/day.c /static.const.char.+day/+2 /}/-
 
-.code: day.c /static.const.char.+day/+2 /}/-
+.code: src/day.c /static.const.char.+day/+2 /}/-
 
 - Between matched lines (exclusive)
 
-        .code: day.c /.+wednesday/+ /.+friday/-
+        .code: src/day.c /.+wednesday/+ /.+friday/-
 
-.code: day.c /.+wednesday/+ /.+friday/-
+.code: src/day.c /.+wednesday/+ /.+friday/-
 
 ---
 
@@ -200,11 +200,7 @@ Include Path
 
 - The default value of "`includepath`" is as follows:
 
-        includepath=.:./src:./code:..:../src:../code
-
-- That means, you can put the file, e.g. "`day.c`", into the "`src`" or "`code`"
-  subdirectory, and later include it as "`.code: day.c`" (instead of "`.code:
-  src/day.c`").
+        includepath=.
 
 ---
 

--- a/samples/example5/src/day.c
+++ b/samples/example5/src/day.c
@@ -1,0 +1,22 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+static const char *day[] = {
+	NULL, 		/* day 0 */
+	"monday",
+	"tuesday",
+	"wednesday",
+	"thursday",
+	"friday",
+	"saturday",
+	"sunday",
+};
+int
+main(int argc, char *argv[])
+{
+	int nth;
+	if (argc > 1 && (nth = atoi(argv[1])) < 7 && nth > 0)
+		printf("%s\n", day[nth]);
+	else	fprintf(stderr, "%s [1-7]\n", argv[0]);
+	return 0;
+}

--- a/src/landslide/generator.py
+++ b/src/landslide/generator.py
@@ -49,6 +49,7 @@ class Generator(object):
         macro_module.FxMacro,
         macro_module.NotesMacro,
         macro_module.QRMacro,
+        macro_module.IncludeMacro,
     ]
     user_css = []
     user_js = []

--- a/src/landslide/generator.py
+++ b/src/landslide/generator.py
@@ -65,7 +65,9 @@ class Generator(object):
             - ``debug``: enables debug mode
             - ``embed``: generates a standalone document, with embedded assets
             - ``encoding``: the encoding to use for this presentation
+            - ``expandtabs``: number of spaces to expand tabs
             - ``extensions``: Comma separated list of markdown extensions
+            - ``includepath``: Colon separated list of directories to locate included files
             - ``logger``: a logger lambda to use for logging
             - ``relative``: enable relative asset urls
             - ``theme``: path to the theme to use for this presentation
@@ -77,7 +79,9 @@ class Generator(object):
                                            'presentation.html')
         self.direct = kwargs.get('direct', False)
         self.embed = kwargs.get('embed', False)
+        self.expandtabs = kwargs.get('expandtabs', macro_module.IncludeMacro.EXPANDTABS)
         self.encoding = kwargs.get('encoding', 'utf8')
+        self.includepath = kwargs.get('includepath', macro_module.IncludeMacro.INCLUDEPATH)
         self.extensions = kwargs.get('extensions', None)
         self.logger = kwargs.get('logger', None)
         self.relative = kwargs.get('relative', False)
@@ -108,6 +112,10 @@ class Generator(object):
             self.destination_file = config.get('destination',
                 self.DEFAULT_DESTINATION)
             self.embed = config.get('embed', False)
+            self.expandtabs = config.get('expandtabs',
+                                         macro_module.IncludeMacro.EXPANDTABS)
+            self.includepath = config.get('includepath',
+                                          macro_module.IncludeMacro.INCLUDEPATH)
             self.relative = config.get('relative', False)
             self.theme = config.get('theme', 'default')
             self.add_user_css(config.get('css', []))
@@ -421,6 +429,10 @@ class Generator(object):
             config['linenos'] = raw_config.get('landslide', 'linenos')
         if raw_config.has_option('landslide', 'embed'):
             config['embed'] = raw_config.getboolean('landslide', 'embed')
+        if raw_config.has_option('landslide', 'expandtabs'):
+            config['expandtabs'] = raw_config.get('landslide', 'expandtabs')
+        if raw_config.has_option('landslide', 'includepath'):
+            config['includepath'] = raw_config.get('landslide', 'includepath')
         if raw_config.has_option('landslide', 'relative'):
             config['relative'] = raw_config.getboolean('landslide', 'relative')
         if raw_config.has_option('landslide', 'css'):
@@ -434,7 +446,10 @@ class Generator(object):
     def process_macros(self, content, source=None):
         """ Processed all macros.
         """
-        macro_options = {'relative': self.relative, 'linenos': self.linenos}
+        macro_options = {
+            'relative': self.relative, 'linenos': self.linenos,
+            'expandtabs': self.expandtabs, 'includepath': self.includepath,
+        }
         classes = []
         for macro_class in self.macros:
             try:

--- a/src/landslide/generator.py
+++ b/src/landslide/generator.py
@@ -430,7 +430,7 @@ class Generator(object):
         if raw_config.has_option('landslide', 'embed'):
             config['embed'] = raw_config.getboolean('landslide', 'embed')
         if raw_config.has_option('landslide', 'expandtabs'):
-            config['expandtabs'] = raw_config.get('landslide', 'expandtabs')
+            config['expandtabs'] = raw_config.getint('landslide', 'expandtabs')
         if raw_config.has_option('landslide', 'includepath'):
             config['includepath'] = raw_config.get('landslide', 'includepath')
         if raw_config.has_option('landslide', 'relative'):

--- a/src/landslide/macro.py
+++ b/src/landslide/macro.py
@@ -380,7 +380,7 @@ class IncludeMacro(Macro):
             if pattern['re'].match(lines[i]):
                 found = i
                 break
-        if not found:
+        if found is None:
             raise IncludeMacro.Error("no matched line for pattern \"%s\""
                                      % pattern['source'])
 

--- a/src/landslide/macro.py
+++ b/src/landslide/macro.py
@@ -189,7 +189,7 @@ class QRMacro(Macro):
         return new_content, classes
 
 
-class IncMacro(Macro):
+class IncludeMacro(Macro):
     """This Macro includes the specified line or, range of lines of the given
        file as a highlighted code block or as is (raw HTML).
     """
@@ -210,9 +210,9 @@ class IncMacro(Macro):
         include_matches = self.include_re.finditer(content)
         if include_matches:
             self.options['expandtabs']  = self.options.get('expandtabs',
-                                                        IncMacro.EXPANDTABS)
+                                                           IncludeMacro.EXPANDTABS)
             self.options['includepath'] = self.options.get('includepath',
-                                                        IncMacro.INCLUDEPATH)
+                                                           IncludeMacro.INCLUDEPATH)
             for match in include_matches:
                 macro   = match.group('macro')
                 argline = match.group('argline')
@@ -222,8 +222,8 @@ class IncMacro(Macro):
                     include_file, start, stop = self.parse_argline(argline)
                     found = self.locate_file(include_file, source)
                     if not found:
-                        raise IncMacro.Error("couldn't locate file \"%s\" from include path \"%s\""
-                                            % (include_file, self.options['includepath']))
+                        raise IncludeMacro.Error("couldn't locate file \"%s\" from include path \"%s\""
+                                                 % (include_file, self.options['includepath']))
                     include_file = found
 
                     include_content = self.get_lines(include_file, start, stop)
@@ -264,7 +264,7 @@ class IncMacro(Macro):
                                     match.group('leading') +
                                     include_content +
                                     match.group('trailing'), 1)
-                except IncMacro.Error, e:
+                except IncludeMacro.Error, e:
                     self.logger(u"Include error at \"%s\": %s" % (context, e), 'warning')
                 except Exception, e:
                     self.logger(u"Unexpected error at \"%s\": %s; please report a bug"
@@ -301,18 +301,18 @@ class IncMacro(Macro):
             try:
                 compiled = re.compile(pattern, re.DOTALL | re.UNICODE)
             except Exception:
-                raise IncMacro.Error("invalid pattern: \"%s\"" % string)
+                raise IncludeMacro.Error("invalid pattern: \"%s\"" % string)
 
             if offset:
                 m = re.search(r'(?P<sign>[+-]?)(?P<offset>\d*)', offset)
                 if not m:
-                    raise IncMacro.Error("invalid offset: \"%s\"" % string)
+                    raise IncludeMacro.Error("invalid offset: \"%s\"" % string)
                 sign, offset = m.group('sign'), m.group('offset')
                 if offset:
                     try:
                         offset = int(offset)
                     except ValueError:
-                        raise IncMacro.Error("invalid offset: \"%s\"" % string)
+                        raise IncludeMacro.Error("invalid offset: \"%s\"" % string)
                 else:
                     offset = 1 if sign else 0
                 if sign == '-':
@@ -347,7 +347,7 @@ class IncMacro(Macro):
             pass
 
         if not path:
-            raise IncMacro.Error("no include file specified")
+            raise IncludeMacro.Error("no include file specified")
 
         return path, start, stop
 
@@ -364,8 +364,8 @@ class IncMacro(Macro):
                     found = f
                     break
         else:
-            raise IncMacro.Error("invalid include path: \"%s\""
-                                 % self.option['includepath'])
+            raise IncludeMacro.Error("invalid include path: \"%s\""
+                                     % self.option['includepath'])
 
         return found
 
@@ -383,12 +383,12 @@ class IncMacro(Macro):
                 found = i
                 break
         if not found:
-            raise IncMacro.Error("no matched line for pattern \"%s\""
-                                 % pattern['source'])
+            raise IncludeMacro.Error("no matched line for pattern \"%s\""
+                                     % pattern['source'])
 
         found += pattern['offset']
         if found < 0 or found >= max:
-            raise IncMacro.Error("offset matched line is out of range [1-%d]" % max)
+            raise IncludeMacro.Error("offset matched line is out of range [1-%d]" % max)
 
         return found
 
@@ -397,7 +397,7 @@ class IncMacro(Macro):
         """Converts a 1-indexed line number to a 0-indexed value."""
         max = len(lines)
         if abs(num) > max:
-            raise IncMacro.Error("line %d is out of range [1-%d]" % (num, max))
+            raise IncludeMacro.Error("line %d is out of range [1-%d]" % (num, max))
         # note the semantics for negative line numbers
         return num - 1 if num > 0 else num
 
@@ -442,7 +442,7 @@ class IncMacro(Macro):
                 if results:
                     result = "".join(results)
                 elif start_index >= stop_index:
-                    raise IncMacro.Error("lines out of order in [%s, %s]" % (start, stop))
+                    raise IncludeMacro.Error("lines out of order in [%s, %s]" % (start, stop))
 
         tabsize = self.options['expandtabs']
         if tabsize > 0:

--- a/src/landslide/macro.py
+++ b/src/landslide/macro.py
@@ -353,7 +353,8 @@ class IncludeMacro(Macro):
 
     def locate_file(self, path, source=None):
         """Locate the given file in includepath"""
-        paths = self.options['includepath'].split(':')
+        paths = [os.path.expanduser(p)
+                 for p in self.options['includepath'].split(':')]
         if '.' not in paths: # current directory should always be in path
             paths.append('.')
         curdir = os.path.dirname(source)

--- a/src/landslide/macro.py
+++ b/src/landslide/macro.py
@@ -195,8 +195,8 @@ class IncludeMacro(Macro):
     """
 
     # Defaults
-    INCLUDEPATH  = '.:./src:./code:..:../src:../code'
-    EXPANDTABS   = 8
+    INCLUDEPATH = '.'
+    EXPANDTABS  = 8
 
     # Macro pattern.
     include_re   = re.compile(
@@ -354,20 +354,17 @@ class IncludeMacro(Macro):
     def locate_file(self, path, source=None):
         """Locate the given file in includepath"""
         paths = self.options['includepath'].split(':')
-        found = None
-        if paths:
-            curdir = os.path.dirname(source)
-            if not curdir: curdir = "."
-            for p in paths:
-                f = os.path.normpath(os.path.join(curdir, p, path))
-                if os.path.exists(f):
-                    found = f
-                    break
-        else:
-            raise IncludeMacro.Error("invalid include path: \"%s\""
-                                     % self.option['includepath'])
+        if '.' not in paths: # current directory should always be in path
+            paths.append('.')
+        curdir = os.path.dirname(source)
+        if not curdir:
+            curdir = "."
+        for p in paths:
+            f = os.path.normpath(os.path.join(curdir, p, path))
+            if os.path.exists(f):
+                return f
 
-        return found
+        return None
 
     def index_matched(self, lines, start, pattern):
         """Identifies the line in lines that matches the pattern, starting from

--- a/src/landslide/macro.py
+++ b/src/landslide/macro.py
@@ -22,6 +22,8 @@ import sys
 import utils
 
 from pygments.lexers import get_lexer_by_name
+from pygments.lexers import get_lexer_for_filename
+from pygments.lexers import guess_lexer
 from pygments.formatters import HtmlFormatter
 
 
@@ -185,3 +187,265 @@ class QRMacro(Macro):
             classes.append(u'has_qr')
 
         return new_content, classes
+
+
+class IncMacro(Macro):
+    """This Macro includes the specified line or, range of lines of the given
+       file as a highlighted code block or as is (raw HTML).
+    """
+
+    # Defaults
+    INCLUDEPATH  = '.:./src:./code:..:../src:../code'
+    EXPANDTABS   = 8
+
+    # Macro pattern.
+    include_re   = re.compile(
+        r'(?P<leading><p>)(?P<macro>\.(code|coden|include):\s?)(?P<argline>.*?)(?P<trailing></p>\n?)',
+        re.DOTALL | re.UNICODE)
+
+    # Custom exception for proper error handling.
+    class Error(Exception): pass
+
+    def process(self, content, source=None):
+        include_matches = self.include_re.finditer(content)
+        if include_matches:
+            self.options['expandtabs']  = self.options.get('expandtabs',
+                                                        IncMacro.EXPANDTABS)
+            self.options['includepath'] = self.options.get('includepath',
+                                                        IncMacro.INCLUDEPATH)
+            for match in include_matches:
+                macro   = match.group('macro')
+                argline = match.group('argline')
+                context = macro + ' ' + argline
+
+                try:
+                    include_file, start, stop = self.parse_argline(argline)
+                    found = self.locate_file(include_file, source)
+                    if not found:
+                        raise IncMacro.Error("couldn't locate file \"%s\" from include path \"%s\""
+                                            % (include_file, self.options['includepath']))
+                    include_file = found
+
+                    include_content = self.get_lines(include_file, start, stop)
+
+                    if '.code' in macro:
+                        if '.coden' in macro:
+                            # .coden
+                            self.options['linenos'] = 'inline'
+                            lineno_status = 'with linenos'
+                        else:
+                            # .code
+                            self.options['linenos'] = False
+                            lineno_status = ''
+                        self.logger(u"Including file \"%s\" as code %s"
+                                    % (include_file, lineno_status), 'notice')
+
+                        try:
+                            # Try to guess language from file extension.
+                            lexer = get_lexer_for_filename(include_file)
+                        except Exception:
+                            try:
+                                # Otherwise fallback to examine the file content.
+                                # Note that this may produce wrong guesses for a small file.
+                                lexer = guess_lexer(content)
+                            except Exception:
+                                self.logger(u"No available pygment lexer found; skipping highlighting",
+                                            'warning')
+                                return content
+
+                        formatter = HtmlFormatter(linenos=self.options['linenos'],
+                                                nobackground=True)
+                        include_content = pygments.highlight(include_content, lexer, formatter)
+                    else:
+                        # .include
+                        self.logger(u"Including file \"%s\" as is" % include_file, 'notice')
+
+                    content = content.replace(match.group(0),
+                                    match.group('leading') +
+                                    include_content +
+                                    match.group('trailing'), 1)
+                except IncMacro.Error, e:
+                    self.logger(u"Include error at \"%s\": %s" % (context, e), 'warning')
+                except Exception, e:
+                    self.logger(u"Unexpected error at \"%s\": %s; please report a bug"
+                                % (context, e), 'warning')
+
+        return content, []
+
+    def parse_pattern(self, string):
+        """Parse a pattern argument"""
+        try:
+            # Simple case: we have a line number.
+            return int(string)
+        except ValueError:
+            pass
+
+        # Otherwise we have a regular expression and (optionally) an offset
+
+        prev = pattern = offset = ''
+        start, stop = 0, len(string)
+        if string[start] in '/':
+            delim = string[start]
+            start += 1
+            for i, c in enumerate(string[start:]):
+                if c == delim and prev != '\\':
+                    stop = i+ start
+                    break
+                prev = c
+            pattern, offset = string[start:stop], string[stop+1:]
+        else:
+            pattern = string
+
+        compiled = None
+        if pattern:
+            try:
+                compiled = re.compile(pattern, re.DOTALL | re.UNICODE)
+            except Exception:
+                raise IncMacro.Error("invalid pattern: \"%s\"" % string)
+
+            if offset:
+                m = re.search(r'(?P<sign>[+-]?)(?P<offset>\d*)', offset)
+                if not m:
+                    raise IncMacro.Error("invalid offset: \"%s\"" % string)
+                sign, offset = m.group('sign'), m.group('offset')
+                if offset:
+                    try:
+                        offset = int(offset)
+                    except ValueError:
+                        raise IncMacro.Error("invalid offset: \"%s\"" % string)
+                else:
+                    offset = 1 if sign else 0
+                if sign == '-':
+                    offset = -offset
+            else:
+                offset = 0
+
+            return {
+                'source': string,
+                're'    : compiled,
+                'offset': offset,
+            }
+
+    def parse_argline(self, argline):
+        """Parse macro arguments"""
+        # XXX Ugly hack to restore the special character '*' which rendered
+        # to <em>...</em> when occured in pair.
+        # For example: "/.*foo/ /.*bar/" becomes  "/.<em>foo/ /.</em>bar/
+        if '<em>' in argline and '</em>' in argline:
+            argline_fixed = re.sub(r'</?em>', '*', argline)
+            self.logger(u"Argline \"%s\" was fixed as \"%s\""
+                        % (argline, argline_fixed), 'warning')
+            argline = argline_fixed
+
+        path = start = stop = None
+        args = iter(argline.split())
+        try:
+            path  = args.next()
+            start = self.parse_pattern(args.next())
+            stop  = self.parse_pattern(args.next())
+        except StopIteration:
+            pass
+
+        if not path:
+            raise IncMacro.Error("no include file specified")
+
+        return path, start, stop
+
+    def locate_file(self, path, source=None):
+        """Locate the given file in includepath"""
+        paths = self.options['includepath'].split(':')
+        found = None
+        if paths:
+            curdir = os.path.dirname(source)
+            if not curdir: curdir = "."
+            for p in paths:
+                f = os.path.normpath(os.path.join(curdir, p, path))
+                if os.path.exists(f):
+                    found = f
+                    break
+        else:
+            raise IncMacro.Error("invalid include path: \"%s\""
+                                 % self.option['includepath'])
+
+        return found
+
+    def index_matched(self, lines, start, pattern):
+        """Identifies the line in lines that matches the pattern, starting from
+           start.  Return value is 0-indexed.
+        """
+        max = len(lines)
+        if pattern['source'] == '$':
+            return max - 1
+
+        found = None
+        for i in range(start, max):
+            if pattern['re'].match(lines[i]):
+                found = i
+                break
+        if not found:
+            raise IncMacro.Error("no matched line for pattern \"%s\""
+                                 % pattern['source'])
+
+        found += pattern['offset']
+        if found < 0 or found >= max:
+            raise IncMacro.Error("offset matched line is out of range [1-%d]" % max)
+
+        return found
+
+
+    def index_numbered(self, lines, num):
+        """Converts a 1-indexed line number to a 0-indexed value."""
+        max = len(lines)
+        if abs(num) > max:
+            raise IncMacro.Error("line %d is out of range [1-%d]" % (num, max))
+        # note the semantics for negative line numbers
+        return num - 1 if num > 0 else num
+
+    def get_lines(self, path, start=None, stop=None):
+        """Gets the lines of the file as a multiline string between the patterns
+           start and stop.  Returns the whole file if no pattern given, one line
+           if one argument given, and multiple lines if two patterns given.
+        """
+        f = open(path)
+        lines = f.readlines()
+        f.close()
+
+        result = ""
+
+        if start is None:
+            # all lines
+            result = "".join(lines)
+        else:
+            if stop is None:
+                # one line
+                if type(start) is int:
+                    result = lines[self.index_numbered(lines, start)]
+                else:
+                    result = lines[self.index_matched(lines, 0, start)]
+            else:
+                # multi lines
+                if type(start) is int:
+                    start_index = self.index_numbered(lines, start)
+                else:
+                    start_index = self.index_matched(lines, 0, start)
+
+                if type(stop) is int:
+                    stop_index = self.index_numbered(lines, stop)
+                else:
+                    stop_index = self.index_matched(lines, start_index, stop)
+
+                results = lines[
+                    start_index:
+                    # -1, which represents the file end, should not wrap up to 0
+                    len(lines) if stop_index == -1 else stop_index + 1
+                ]
+                if results:
+                    result = "".join(results)
+                elif start_index >= stop_index:
+                    raise IncMacro.Error("lines out of order in [%s, %s]" % (start, stop))
+
+        tabsize = self.options['expandtabs']
+        if tabsize > 0:
+            result = result.expandtabs(tabsize)
+
+        return result

--- a/src/landslide/main.py
+++ b/src/landslide/main.py
@@ -22,6 +22,11 @@ try:
 except ImportError:
     import generator
 
+try:
+    from landslide import macro
+except ImportError:
+    import macro
+
 from optparse import OptionParser
 
 
@@ -59,11 +64,25 @@ def _parse_options():
         default="presentation.html")
 
     parser.add_option(
+        "-E", "--expandtabs",
+        type="int",
+        dest="expandtabs",
+        help="Number of spaces to expand tabs in included files.",
+        default=macro.IncludeMacro.EXPANDTABS)
+
+    parser.add_option(
         "-e", "--encoding",
         dest="encoding",
         help="The encoding of your files (defaults to utf8)",
         metavar="ENCODING",
         default="utf8")
+
+    parser.add_option(
+        "-I", "--includepath",
+        dest="includepath",
+        help="Colon separated list of directories to locate included files.",
+        metavar="FILE",
+        default=macro.IncludeMacro.INCLUDEPATH)
 
     parser.add_option(
         "-i", "--embed",

--- a/src/landslide/main.py
+++ b/src/landslide/main.py
@@ -68,6 +68,7 @@ def _parse_options():
         type="int",
         dest="expandtabs",
         help="Number of spaces to expand tabs in included files.",
+        metavar="INTEGER",
         default=macro.IncludeMacro.EXPANDTABS)
 
     parser.add_option(
@@ -81,7 +82,7 @@ def _parse_options():
         "-I", "--includepath",
         dest="includepath",
         help="Colon separated list of directories to locate included files.",
-        metavar="FILE",
+        metavar="PATH",
         default=macro.IncludeMacro.INCLUDEPATH)
 
     parser.add_option(

--- a/src/landslide/tests.py
+++ b/src/landslide/tests.py
@@ -238,41 +238,41 @@ class NotesMacroTest(BaseTestCase):
         self.assertEquals(r[1], [u'has_notes'])
 
 
-class IncMacroTest(BaseTestCase):
+class IncludeMacroTest(BaseTestCase):
     def test_process_whole_file(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
-        m = macro.IncMacro(self.logtest)
+        m = macro.IncludeMacro(self.logtest)
         content, classes = m.process('<p>.coden: day.c</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*stdio\.h', content))
         self.assertTrue(re.search(r'"lineno"> *22<.*>}<', content))
         self.assertFalse(re.search(r'"lineno"> *23<', content))
     def test_process_oneline_num_positive(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
-        m = macro.IncMacro(self.logtest)
+        m = macro.IncludeMacro(self.logtest)
         content, classes = m.process('<p>.coden: day.c 8</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
         self.assertFalse(re.search(r'"lineno"> *2<', content))
     def test_process_oneline_num_negative(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
-        m = macro.IncMacro(self.logtest)
+        m = macro.IncludeMacro(self.logtest)
         content, classes = m.process('<p>.coden: day.c -1</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*>}<', content))
         self.assertFalse(re.search(r'"lineno"> *2<', content))
     def test_process_oneline_dollar(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
-        m = macro.IncMacro(self.logtest)
+        m = macro.IncludeMacro(self.logtest)
         content, classes = m.process('<p>.coden: day.c $</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*>}<', content))
         self.assertFalse(re.search(r'"lineno"> *2<', content))
     def test_process_oneline_pattern(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
-        m = macro.IncMacro(self.logtest)
+        m = macro.IncludeMacro(self.logtest)
         content, classes = m.process('<p>.coden: day.c /.+wednesday/</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
         self.assertFalse(re.search(r'"lineno"> *2<', content))
     def test_process_oneline_errors(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
-        m = macro.IncMacro(self.logtest)
+        m = macro.IncludeMacro(self.logtest)
         self.assertRaises(WarningMessage, m.process,
                           '<p>.code: day.c /foo/</p>', source)
         self.assertRaises(WarningMessage, m.process,
@@ -281,7 +281,7 @@ class IncMacroTest(BaseTestCase):
                           '<p>.code: day.c -1000</p>', source)
     def test_process_multiline_pattern(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
-        m = macro.IncMacro(self.logtest)
+        m = macro.IncludeMacro(self.logtest)
         content, classes = m.process('<p>.coden: day.c /.+wednesday/ /.+friday/</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
         self.assertTrue(re.search(r'"lineno"> *2<.*thursday', content))
@@ -289,7 +289,7 @@ class IncMacroTest(BaseTestCase):
         self.assertFalse(re.search(r'"lineno"> *4<', content))
     def test_process_multiline_num_positive(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
-        m = macro.IncMacro(self.logtest)
+        m = macro.IncludeMacro(self.logtest)
         content, classes = m.process('<p>.coden: day.c 8 10</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
         self.assertTrue(re.search(r'"lineno"> *2<.*thursday', content))
@@ -297,7 +297,7 @@ class IncMacroTest(BaseTestCase):
         self.assertFalse(re.search(r'"lineno"> *4<', content))
     def test_process_multiline_num_negative(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
-        m = macro.IncMacro(self.logtest)
+        m = macro.IncludeMacro(self.logtest)
         content, classes = m.process('<p>.coden: day.c -15 -13</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
         self.assertTrue(re.search(r'"lineno"> *2<.*thursday', content))
@@ -305,7 +305,7 @@ class IncMacroTest(BaseTestCase):
         self.assertFalse(re.search(r'"lineno"> *4<', content))
     def test_process_multiline_errors(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
-        m = macro.IncMacro(self.logtest)
+        m = macro.IncludeMacro(self.logtest)
         self.assertRaises(WarningMessage, m.process,
                           '<p>.code: day.c /foo/ /bar/</p>', source)
         self.assertRaises(WarningMessage, m.process,
@@ -314,7 +314,7 @@ class IncMacroTest(BaseTestCase):
                           '<p>.code: day.c -5 -10</p>', source)
     def test_process_offset_simple(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
-        m = macro.IncMacro(self.logtest)
+        m = macro.IncludeMacro(self.logtest)
         content, classes = m.process('<p>.coden: day.c /main\(.+\)/- /}/</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*int', content))
         self.assertTrue(re.search(r'"lineno"> *2<.*main', content))
@@ -322,14 +322,14 @@ class IncMacroTest(BaseTestCase):
         self.assertFalse(re.search(r'"lineno"> *10<', content))
     def test_process_offset_fancy(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
-        m = macro.IncMacro(self.logtest)
+        m = macro.IncludeMacro(self.logtest)
         content, classes = m.process('<p>.coden: day.c /static.const.char.+day/+2 /}/-</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*monday', content))
         self.assertTrue(re.search(r'"lineno"> *7<.*sunday', content))
         self.assertFalse(re.search(r'"lineno"> *8<', content))
     def test_process_offset_errors(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
-        m = macro.IncMacro(self.logtest)
+        m = macro.IncludeMacro(self.logtest)
         self.assertRaises(WarningMessage, m.process,
                           '<p>.code: day.c /main/+8</p>', source)
         self.assertRaises(WarningMessage, m.process,
@@ -338,7 +338,7 @@ class IncMacroTest(BaseTestCase):
                           '<p>.code: day.c /main/+4 /}/-4</p>', source)
     def test_process_option_includepath(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
-        m = macro.IncMacro(self.logtest)
+        m = macro.IncludeMacro(self.logtest)
         includepath_old = m.options['includepath']
         m.options['includepath'] = '.'
         self.assertRaises(WarningMessage, m.process,
@@ -348,7 +348,7 @@ class IncMacroTest(BaseTestCase):
         m.options['includepath'] = includepath_old
     def test_process_option_expandtabs(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
-        m = macro.IncMacro(self.logtest)
+        m = macro.IncludeMacro(self.logtest)
         expandtabs_old = m.options['expandtabs']
         ts = m.options['expandtabs'] = 4
         content, classes = m.process('<p>.coden: day.c /.+wednesday/</p>', source)

--- a/src/landslide/tests.py
+++ b/src/landslide/tests.py
@@ -238,6 +238,127 @@ class NotesMacroTest(BaseTestCase):
         self.assertEquals(r[1], [u'has_notes'])
 
 
+class IncMacroTest(BaseTestCase):
+    def test_process_whole_file(self):
+        source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
+        m = macro.IncMacro(self.logtest)
+        content, classes = m.process('<p>.coden: day.c</p>', source)
+        self.assertTrue(re.search(r'"lineno"> *1<.*stdio\.h', content))
+        self.assertTrue(re.search(r'"lineno"> *22<.*>}<', content))
+        self.assertFalse(re.search(r'"lineno"> *23<', content))
+    def test_process_oneline_num_positive(self):
+        source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
+        m = macro.IncMacro(self.logtest)
+        content, classes = m.process('<p>.coden: day.c 8</p>', source)
+        self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
+        self.assertFalse(re.search(r'"lineno"> *2<', content))
+    def test_process_oneline_num_negative(self):
+        source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
+        m = macro.IncMacro(self.logtest)
+        content, classes = m.process('<p>.coden: day.c -1</p>', source)
+        self.assertTrue(re.search(r'"lineno"> *1<.*>}<', content))
+        self.assertFalse(re.search(r'"lineno"> *2<', content))
+    def test_process_oneline_dollar(self):
+        source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
+        m = macro.IncMacro(self.logtest)
+        content, classes = m.process('<p>.coden: day.c $</p>', source)
+        self.assertTrue(re.search(r'"lineno"> *1<.*>}<', content))
+        self.assertFalse(re.search(r'"lineno"> *2<', content))
+    def test_process_oneline_pattern(self):
+        source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
+        m = macro.IncMacro(self.logtest)
+        content, classes = m.process('<p>.coden: day.c /.+wednesday/</p>', source)
+        self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
+        self.assertFalse(re.search(r'"lineno"> *2<', content))
+    def test_process_oneline_errors(self):
+        source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
+        m = macro.IncMacro(self.logtest)
+        self.assertRaises(WarningMessage, m.process,
+                          '<p>.code: day.c /foo/</p>', source)
+        self.assertRaises(WarningMessage, m.process,
+                          '<p>.code: day.c 1000</p>', source)
+        self.assertRaises(WarningMessage, m.process,
+                          '<p>.code: day.c -1000</p>', source)
+    def test_process_multiline_pattern(self):
+        source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
+        m = macro.IncMacro(self.logtest)
+        content, classes = m.process('<p>.coden: day.c /.+wednesday/ /.+friday/</p>', source)
+        self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
+        self.assertTrue(re.search(r'"lineno"> *2<.*thursday', content))
+        self.assertTrue(re.search(r'"lineno"> *3<.*friday', content))
+        self.assertFalse(re.search(r'"lineno"> *4<', content))
+    def test_process_multiline_num_positive(self):
+        source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
+        m = macro.IncMacro(self.logtest)
+        content, classes = m.process('<p>.coden: day.c 8 10</p>', source)
+        self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
+        self.assertTrue(re.search(r'"lineno"> *2<.*thursday', content))
+        self.assertTrue(re.search(r'"lineno"> *3<.*friday', content))
+        self.assertFalse(re.search(r'"lineno"> *4<', content))
+    def test_process_multiline_num_negative(self):
+        source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
+        m = macro.IncMacro(self.logtest)
+        content, classes = m.process('<p>.coden: day.c -15 -13</p>', source)
+        self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
+        self.assertTrue(re.search(r'"lineno"> *2<.*thursday', content))
+        self.assertTrue(re.search(r'"lineno"> *3<.*friday', content))
+        self.assertFalse(re.search(r'"lineno"> *4<', content))
+    def test_process_multiline_errors(self):
+        source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
+        m = macro.IncMacro(self.logtest)
+        self.assertRaises(WarningMessage, m.process,
+                          '<p>.code: day.c /foo/ /bar/</p>', source)
+        self.assertRaises(WarningMessage, m.process,
+                          '<p>.code: day.c 11 7</p>', source)
+        self.assertRaises(WarningMessage, m.process,
+                          '<p>.code: day.c -5 -10</p>', source)
+    def test_process_offset_simple(self):
+        source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
+        m = macro.IncMacro(self.logtest)
+        content, classes = m.process('<p>.coden: day.c /main\(.+\)/- /}/</p>', source)
+        self.assertTrue(re.search(r'"lineno"> *1<.*int', content))
+        self.assertTrue(re.search(r'"lineno"> *2<.*main', content))
+        self.assertTrue(re.search(r'"lineno"> *9<.*}', content))
+        self.assertFalse(re.search(r'"lineno"> *10<', content))
+    def test_process_offset_fancy(self):
+        source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
+        m = macro.IncMacro(self.logtest)
+        content, classes = m.process('<p>.coden: day.c /static.const.char.+day/+2 /}/-</p>', source)
+        self.assertTrue(re.search(r'"lineno"> *1<.*monday', content))
+        self.assertTrue(re.search(r'"lineno"> *7<.*sunday', content))
+        self.assertFalse(re.search(r'"lineno"> *8<', content))
+    def test_process_offset_errors(self):
+        source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
+        m = macro.IncMacro(self.logtest)
+        self.assertRaises(WarningMessage, m.process,
+                          '<p>.code: day.c /main/+8</p>', source)
+        self.assertRaises(WarningMessage, m.process,
+                          '<p>.code: day.c /main/-15</p>', source)
+        self.assertRaises(WarningMessage, m.process,
+                          '<p>.code: day.c /main/+4 /}/-4</p>', source)
+    def test_process_option_includepath(self):
+        source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
+        m = macro.IncMacro(self.logtest)
+        includepath_old = m.options['includepath']
+        m.options['includepath'] = '.'
+        self.assertRaises(WarningMessage, m.process,
+                          '<p>.coden: day.c /.+wednesday/</p>', source)
+        content, classes = m.process('<p>.coden: src/day.c /.+wednesday/</p>', source)
+        self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
+        m.options['includepath'] = includepath_old
+    def test_process_option_expandtabs(self):
+        source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
+        m = macro.IncMacro(self.logtest)
+        expandtabs_old = m.options['expandtabs']
+        ts = m.options['expandtabs'] = 4
+        content, classes = m.process('<p>.coden: day.c /.+wednesday/</p>', source)
+        self.assertTrue(re.search(r'"lineno"> *1<.*>\s?[ ]{' + str(ts) + '}<.*wednesday', content))
+        ts = m.options['expandtabs'] = 12
+        content, classes = m.process('<p>.coden: day.c /.+wednesday/</p>', source)
+        self.assertTrue(re.search(r'"lineno"> *1<.*>\s?[ ]{' + str(ts) + '}<.*wednesday', content))
+        m.options['expandtabs'] = expandtabs_old
+
+
 class ParserTest(BaseTestCase):
     def test___init__(self):
         self.assertEquals(Parser('.md').format, 'markdown')

--- a/src/landslide/tests.py
+++ b/src/landslide/tests.py
@@ -242,47 +242,47 @@ class IncludeMacroTest(BaseTestCase):
     def test_process_whole_file(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
         m = macro.IncludeMacro(self.logtest)
-        content, classes = m.process('<p>.coden: day.c</p>', source)
+        content, classes = m.process('<p>.coden: src/day.c</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*stdio\.h', content))
         self.assertTrue(re.search(r'"lineno"> *22<.*>}<', content))
         self.assertFalse(re.search(r'"lineno"> *23<', content))
     def test_process_oneline_num_positive(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
         m = macro.IncludeMacro(self.logtest)
-        content, classes = m.process('<p>.coden: day.c 8</p>', source)
+        content, classes = m.process('<p>.coden: src/day.c 8</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
         self.assertFalse(re.search(r'"lineno"> *2<', content))
     def test_process_oneline_num_negative(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
         m = macro.IncludeMacro(self.logtest)
-        content, classes = m.process('<p>.coden: day.c -1</p>', source)
+        content, classes = m.process('<p>.coden: src/day.c -1</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*>}<', content))
         self.assertFalse(re.search(r'"lineno"> *2<', content))
     def test_process_oneline_dollar(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
         m = macro.IncludeMacro(self.logtest)
-        content, classes = m.process('<p>.coden: day.c $</p>', source)
+        content, classes = m.process('<p>.coden: src/day.c $</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*>}<', content))
         self.assertFalse(re.search(r'"lineno"> *2<', content))
     def test_process_oneline_pattern(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
         m = macro.IncludeMacro(self.logtest)
-        content, classes = m.process('<p>.coden: day.c /.+wednesday/</p>', source)
+        content, classes = m.process('<p>.coden: src/day.c /.+wednesday/</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
         self.assertFalse(re.search(r'"lineno"> *2<', content))
     def test_process_oneline_errors(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
         m = macro.IncludeMacro(self.logtest)
         self.assertRaises(WarningMessage, m.process,
-                          '<p>.code: day.c /foo/</p>', source)
+                          '<p>.code: src/day.c /foo/</p>', source)
         self.assertRaises(WarningMessage, m.process,
-                          '<p>.code: day.c 1000</p>', source)
+                          '<p>.code: src/day.c 1000</p>', source)
         self.assertRaises(WarningMessage, m.process,
-                          '<p>.code: day.c -1000</p>', source)
+                          '<p>.code: src/day.c -1000</p>', source)
     def test_process_multiline_pattern(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
         m = macro.IncludeMacro(self.logtest)
-        content, classes = m.process('<p>.coden: day.c /.+wednesday/ /.+friday/</p>', source)
+        content, classes = m.process('<p>.coden: src/day.c /.+wednesday/ /.+friday/</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
         self.assertTrue(re.search(r'"lineno"> *2<.*thursday', content))
         self.assertTrue(re.search(r'"lineno"> *3<.*friday', content))
@@ -290,7 +290,7 @@ class IncludeMacroTest(BaseTestCase):
     def test_process_multiline_num_positive(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
         m = macro.IncludeMacro(self.logtest)
-        content, classes = m.process('<p>.coden: day.c 8 10</p>', source)
+        content, classes = m.process('<p>.coden: src/day.c 8 10</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
         self.assertTrue(re.search(r'"lineno"> *2<.*thursday', content))
         self.assertTrue(re.search(r'"lineno"> *3<.*friday', content))
@@ -298,7 +298,7 @@ class IncludeMacroTest(BaseTestCase):
     def test_process_multiline_num_negative(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
         m = macro.IncludeMacro(self.logtest)
-        content, classes = m.process('<p>.coden: day.c -15 -13</p>', source)
+        content, classes = m.process('<p>.coden: src/day.c -15 -13</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*wednesday', content))
         self.assertTrue(re.search(r'"lineno"> *2<.*thursday', content))
         self.assertTrue(re.search(r'"lineno"> *3<.*friday', content))
@@ -307,15 +307,15 @@ class IncludeMacroTest(BaseTestCase):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
         m = macro.IncludeMacro(self.logtest)
         self.assertRaises(WarningMessage, m.process,
-                          '<p>.code: day.c /foo/ /bar/</p>', source)
+                          '<p>.code: src/day.c /foo/ /bar/</p>', source)
         self.assertRaises(WarningMessage, m.process,
-                          '<p>.code: day.c 11 7</p>', source)
+                          '<p>.code: src/day.c 11 7</p>', source)
         self.assertRaises(WarningMessage, m.process,
-                          '<p>.code: day.c -5 -10</p>', source)
+                          '<p>.code: src/day.c -5 -10</p>', source)
     def test_process_offset_simple(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
         m = macro.IncludeMacro(self.logtest)
-        content, classes = m.process('<p>.coden: day.c /main\(.+\)/- /}/</p>', source)
+        content, classes = m.process('<p>.coden: src/day.c /main\(.+\)/- /}/</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*int', content))
         self.assertTrue(re.search(r'"lineno"> *2<.*main', content))
         self.assertTrue(re.search(r'"lineno"> *9<.*}', content))
@@ -323,7 +323,7 @@ class IncludeMacroTest(BaseTestCase):
     def test_process_offset_fancy(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
         m = macro.IncludeMacro(self.logtest)
-        content, classes = m.process('<p>.coden: day.c /static.const.char.+day/+2 /}/-</p>', source)
+        content, classes = m.process('<p>.coden: src/day.c /static.const.char.+day/+2 /}/-</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*monday', content))
         self.assertTrue(re.search(r'"lineno"> *7<.*sunday', content))
         self.assertFalse(re.search(r'"lineno"> *8<', content))
@@ -331,11 +331,11 @@ class IncludeMacroTest(BaseTestCase):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
         m = macro.IncludeMacro(self.logtest)
         self.assertRaises(WarningMessage, m.process,
-                          '<p>.code: day.c /main/+8</p>', source)
+                          '<p>.code: src/day.c /main/+8</p>', source)
         self.assertRaises(WarningMessage, m.process,
-                          '<p>.code: day.c /main/-15</p>', source)
+                          '<p>.code: src/day.c /main/-15</p>', source)
         self.assertRaises(WarningMessage, m.process,
-                          '<p>.code: day.c /main/+4 /}/-4</p>', source)
+                          '<p>.code: src/day.c /main/+4 /}/-4</p>', source)
     def test_process_option_includepath(self):
         source = os.path.join(SAMPLES_DIR, 'example5', 'slides.md')
         m = macro.IncludeMacro(self.logtest)
@@ -351,10 +351,10 @@ class IncludeMacroTest(BaseTestCase):
         m = macro.IncludeMacro(self.logtest)
         expandtabs_old = m.options['expandtabs']
         ts = m.options['expandtabs'] = 4
-        content, classes = m.process('<p>.coden: day.c /.+wednesday/</p>', source)
+        content, classes = m.process('<p>.coden: src/day.c /.+wednesday/</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*>\s?[ ]{' + str(ts) + '}<.*wednesday', content))
         ts = m.options['expandtabs'] = 12
-        content, classes = m.process('<p>.coden: day.c /.+wednesday/</p>', source)
+        content, classes = m.process('<p>.coden: src/day.c /.+wednesday/</p>', source)
         self.assertTrue(re.search(r'"lineno"> *1<.*>\s?[ ]{' + str(ts) + '}<.*wednesday', content))
         m.options['expandtabs'] = expandtabs_old
 


### PR DESCRIPTION
I've added a new macro: `IncludeMacro` to include external files (mainly code files).  Here is a brief summary of this feature branch:

- Macro implementation in `macro.py`
- Unit tests in `tests.py`
- Documentation in `samples/example5`

Please see the `samples/example5/slides.md` for details.  Feel free to fix my poor English.