### PR TITLE
Landslide now understands pygments lexer names with special characters in them

### DIFF
--- a/src/landslide/macro.py
+++ b/src/landslide/macro.py
@@ -50,7 +50,7 @@ class CodeHighlightingMacro(Macro):
        Pygments.
     """
     code_blocks_re = re.compile(
-        r'(<pre.+?>(<code>)?\s?!(\w+?)\n(.*?)(</code>)?</pre>)',
+        r'(<pre.+?>(<code>)?\s?!(\S+?)\n(.*?)(</code>)?</pre>)',
         re.UNICODE | re.MULTILINE | re.DOTALL)
 
     html_entity_re = re.compile('&(\w+?);')


### PR DESCRIPTION
Code block regex now captures all pygments lexer shrort-names.
