### PR TITLE
fix to embed images defined in CSS

### DIFF
--- a/src/landslide/generator.py
+++ b/src/landslide/generator.py
@@ -482,12 +482,35 @@ class Generator(object):
 
             for img_url in images:
                 img_url = img_url.replace('"', '').replace("'", '')
-
-                source = os.path.join(THEMES_DIR, self.theme, 'css')
+                if self.theme_dir:
+                    source = os.path.join(self.theme_dir, 'css')
+                else:
+                    source = os.path.join(THEMES_DIR, self.theme, 'css')
 
                 encoded_url = utils.encode_image_from_url(img_url, source)
+                if encoded_url:
+                    html = html.replace(img_url, encoded_url, 1)
+                    self.log("Embedded theme image %s from theme directory %s" % (img_url, source))
+                else:
+                    # Missing file in theme directory. Try user_css folders
+                    found = False
+                    for css_entry in context['user_css']:
+                        directory = os.path.dirname(css_entry['path_url'])
+                        if not directory: 
+                            directory = "."
 
-                html = html.replace(img_url, encoded_url, 1)
+                        encoded_url = utils.encode_image_from_url(img_url, directory)
+                            
+                        if encoded_url:
+                            found = True
+                            html = html.replace(img_url, encoded_url, 1)
+                            self.log("Embedded theme image %s from directory %s" % (img_url, directory))
+                    
+                    if not found:
+                        #Missing image file, etc...
+                        self.log(u"Failed to embed theme image %s" % img_url)
+
+
 
         return html
 


### PR DESCRIPTION
This commit fixes the issue where landslide cannot find an image defined within a CSS file where the image is not within the supplied theme directory. This is useful when using a custom theme or background images in custom css files defined within a config file.

I've based this on ackdesha's patch in PR 110, so it also continues to render if it cannot find the image.
