### PR TITLE
Support .mdwn file extension for Markdown sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ If you want to stay on the edge:
 
 ## Markdown
 
-- Your Markdown source files must be suffixed by `.md`, `.markdn`, `.mdown` or
-  `.markdown`
+- Your Markdown source files must be suffixed by `.md`, `.markdn`, `.mdwn`,
+  `.mdown` or `.markdown`
 - To create a title slide, render a single `h1` element (eg. `# My Title`)
 - Separate your slides with a horizontal rule (`---` in markdown) except at the
   end of md files

--- a/src/landslide/parser.py
+++ b/src/landslide/parser.py
@@ -17,7 +17,7 @@
 import re
 
 SUPPORTED_FORMATS = {
-    'markdown':         ['.mdown', '.markdown', '.markdn', '.md', '.mdn'],
+    'markdown':         ['.mdown', '.markdown', '.markdn', '.md', '.mdn', '.mdwn'],
     'restructuredtext': ['.rst', '.rest'],
     'textile':          ['.textile'],
 }


### PR DESCRIPTION
.mdwn is used by IkiWiki http://ikiwiki.info Wiki compiler for Markdown
formatted pages. Support this extension in Landslide, too.
