### PR TITLE
Do not embed external JS files

### DIFF
--- a/src/landslide/themes/default/base.html
+++ b/src/landslide/themes/default/base.html
@@ -57,7 +57,7 @@
     <script type="text/javascript" src="{{ js.path_url }}"></script>
     {% endif %}
     {% for js in user_js %}
-      {% if embed %}
+      {% if embed and js.contents %}
       <script>
         {{ js.contents }}
       </script>


### PR DESCRIPTION
Currently an user external JS file has no content and is not successfully embedded  if `Embed = True`. With this commit, the external link is inserted.
