### PR TITLE
auto add HR for rst source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ dist/
 landslide.sublime-project
 docs/_build
 venv
+slides.html
+slides_without_hr.html

--- a/samples/example3/Makefile
+++ b/samples/example3/Makefile
@@ -1,0 +1,5 @@
+all:
+	landslide slides.rst -d slides.html
+	landslide slides_without_hr.rst -d slides_without_hr.html
+	diff slides.html slides_without_hr.html
+

--- a/samples/example3/slides_without_hr.rst
+++ b/samples/example3/slides_without_hr.rst
@@ -1,0 +1,68 @@
+Slides in ReStructuredText
+==========================
+
+Here we Go
+----------
+
+This is foo
+
+This is bar
+
+This is ünicô∂e
+
+- This
+- Is
+- A
+- List
+
+Middle Title Slide
+==================
+
+Here we Go Again
+----------------
+
+This is foo again
+
+This is bargain
+
+RST Features
+------------
+
+*italics*
+
+**bold**
+
+``monospace``
+
+http://docutils.sf.net/
+
+1. one
+2. two
+
+Some code now
+-------------
+
+Let me give you this snippet:
+
+.. sourcecode:: python
+
+    def foo():
+        "just a test"
+        print bar
+
+Then this one, a more ReSTful way (haha, nerd joke spotted) using the ``sourcecode`` directive:
+
+.. sourcecode:: python
+
+    def bar():
+        """pretty cool"""
+        print baz
+
+
+Then this other one with the ``code-block`` directive:
+
+.. code-block:: python
+
+    def batman():
+        "foobar"
+        return robin

--- a/src/landslide/generator.py
+++ b/src/landslide/generator.py
@@ -32,7 +32,7 @@ from parser import Parser
 
 BASE_DIR = os.path.dirname(__file__)
 THEMES_DIR = os.path.join(BASE_DIR, 'themes')
-TOC_MAX_LEVEL = 2
+TOC_MAX_LEVEL = 4
 VALID_LINENOS = ('no', 'inline', 'table')
 
 
@@ -414,6 +414,7 @@ class Generator(object):
                 continue
             self.num_slides += 1
             slide_number = slide_vars['number'] = self.num_slides
+            #print slide_vars['title'], slide_vars['level'], slide_number
             if slide_vars['level'] and slide_vars['level'] <= TOC_MAX_LEVEL:
                 self.add_toc_entry(slide_vars['title'], slide_vars['level'],
                                    slide_number)
@@ -508,7 +509,6 @@ class Generator(object):
         template = jinja2.Template(template_src.read())
         slides = self.fetch_contents(self.source)
         context = self.get_template_vars(slides)
-
         html = template.render(context)
 
         if self.embed:


### PR DESCRIPTION
I found that in `samples/example3/slides.rst`, there is one `hr` before every `header`, 

so we can add it automatic, which make the source file much easy to read 

see `samples/example3/slides_without_hr.rst` as a example, it Compatible the source with `hr`

    Middle Title Slide
    ==================

    Here we Go Again
    ----------------

will change to

    ----

    Middle Title Slide
    ==================

    ----

    Here we Go Again
    ----------------



