### PR TITLE
embed all theme images

### DIFF
--- a/src/landslide/generator.py
+++ b/src/landslide/generator.py
@@ -504,7 +504,7 @@ class Generator(object):
         html = template.render(context)
 
         if self.embed:
-            images = re.findall(r'\s+background(?:-image)?:\surl\((.+?)\).+;',
+            images = re.findall(r'\s+background(?:-image)?:\surl\((.+?)\)[^;]+;',
                             html, re.DOTALL | re.UNICODE)
 
             for img_url in images:


### PR DESCRIPTION
Without this change, the regex matches all possible URLs in the first
hit, which practically means that only the first background URL gets
embedded.

This makes the regex less "greedy", which means that the subsequent
images are all matched, and multiple background URLs get embedded
properly.