### PR TITLE
Identify each slide by a numbered class

### DIFF
--- a/src/landslide/themes/default/base.html
+++ b/src/landslide/themes/default/base.html
@@ -85,7 +85,7 @@
       {% for slide in slides %}
       <!-- slide source: {% if slide.source %}{{ slide.source.rel_path }}{% endif %} -->
       <div class="slide-wrapper">
-        <div class="slide{% if slide.classes %}{% for class in slide.classes %} {{ class }}{% endfor %}{% endif %}">
+        <div class="slide{% if slide.classes %}{% for class in slide.classes %} {{ class }}{% endfor %}{% endif %} slide-{{slide.number}}">
           <div class="inner">
             {% if slide.header %}
             <header>{{ slide.header }}</header>


### PR DESCRIPTION
It's possible that some specific slide needs to be identified
separately in the stylesheet.  By assigning each slide a special class
associated with its number in the deck, a custom theme can now include
a targeted modification for any specific slide.