### PR TITLE
Prevent text before header from being stripped

### DIFF
--- a/src/landslide/generator.py
+++ b/src/landslide/generator.py
@@ -361,7 +361,7 @@ class Generator(object):
 
             slide_src = slide_src[:find.start()]
 
-        find = re.search(r'(<h(\d+?).*?>(.+?)</h\d>)\s?(.+)?', slide_src,
+        find = re.search(r'^\s+(<h(\d+?).*?>(.+?)</h\d>)\s?(.+)?', slide_src,
                          re.DOTALL | re.UNICODE)
 
         if not find:


### PR DESCRIPTION
Example :

    ------------------------
    This is some normal text that will be stripped from the slide
    
    ### This some sub-header in the middle of the slide causing this