### PR TITLE
make the default theme auto resize the pictures

### DIFF
--- a/src/landslide/themes/default/css/screen.css
+++ b/src/landslide/themes/default/css/screen.css
@@ -309,7 +309,7 @@ section, .slide header:only-child h1 {
   overflow: hidden;
 }
 
-img { display: block; margin: auto; }
+img { display: block; margin: auto; max-width: 100%; height: auto; width: expression(this.width > 600 ? "600px" : this.width); }
 
 section img.align-center {
   display: block;


### PR DESCRIPTION
Modify the `screen.css` of the default theme, make it auto resize the pictures in the slides.

Picture show before the modify:
![before](http://wenchao-img.qiniudn.com/f2aa37f41766afeac86166fc2a9f71a2.png)

Picture show after the modify:
![after](http://wenchao-img.qiniudn.com/b0d0fa697836ca040f33cb07e4fb8233.png)
