### PR TITLE
Prevent ontouchmove

### DIFF
--- a/src/landslide/themes/default/js/slides.js
+++ b/src/landslide/themes/default/js/slides.js
@@ -3,7 +3,9 @@ function main() {
     // other IE only stuff we won't try to run JS for IE.
     // It will run though when using Google Chrome Frame
     if (document.all) { return; }
-
+    document.body.addEventListener('ontouchmove', function(event) {
+        event.preventDefault();
+    }, false);
     var currentSlideNo;
     var notesOn = false;
     var expanded = false;


### PR DESCRIPTION
I've found this small change to fix some annoying issues when using the touchscreen to change slides in my phone.