### PR TITLE
Fix double mouse wheel scroll on IE/Opera/Chrome/Safari

### DIFF
--- a/landslide/themes/default/js/slides.js
+++ b/landslide/themes/default/js/slides.js
@@ -560,7 +560,7 @@ function main() {
         document.addEventListener('keydown', checkModifierKeyDown, false);
         document.addEventListener('DOMMouseScroll', handleWheel, false);
 
-        window.onmousewheel = document.onmousewheel = handleWheel;
+        document.onmousewheel = handleWheel;
         window.onresize = expandSlides;
 
         for (var i = 0, el; el = slides[i]; i++) {

--- a/landslide/themes/leapmotion/js/slides.js
+++ b/landslide/themes/leapmotion/js/slides.js
@@ -612,7 +612,7 @@ function main() {
         document.addEventListener('keydown', checkModifierKeyDown, false);
         document.addEventListener('DOMMouseScroll', handleWheel, false);
 
-        window.onmousewheel = document.onmousewheel = handleWheel;
+        document.onmousewheel = handleWheel;
         window.onresize = expandSlides;
 
         for (var i = 0, el; el = slides[i]; i++) {


### PR DESCRIPTION
The declaration `window.onmousewheel=document.onmousewheel=handleWheel;` loads both window.onmousewheel and document.onmousewheel with the scrolling handler. This causes the wheel to go 2 slides forwards/backwards on Chrome (noticed on Chrome 41 on Linux), and other browsers (but not Firefox, which is handled by `document.addEventListener('DOMMouseScroll', handleWheel, false);`.