### PR TITLE
Proposed/working macro option

### DIFF
--- a/landslide/__init__.py
+++ b/landslide/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'landslide'
-__version__ = '1.1.3'
+__version__ = '1.2.0'
 __author__ = 'Adam Zapletal'
 __author_email__ = 'adamzap@gmail.com'
 __license__ = 'Apache 2.0'

--- a/landslide/main.py
+++ b/landslide/main.py
@@ -2,18 +2,16 @@
 # -*- coding: utf-8 -*-
 
 import sys
-
 from optparse import OptionParser
 
-from . import generator
-from . import __version__
+from . import __version__, generator
 
 
 def _parse_options():
     """Parses landslide's command line options"""
 
     parser = OptionParser(
-        usage="%prog [options] input.md ...",
+        usage="%prog [options] (input.md|config.cfg)",
         description="Generates an HTML5 or PDF "
                     "slideshow from Markdown or other formats",
         epilog="Note: PDF export requires the `prince` program: "
@@ -136,6 +134,14 @@ def _parse_options():
         dest="math_output",
         help="Enable mathematical output using MathJax",
         default=False
+    )
+
+    parser.add_option(
+        "-M", "--macro",
+        dest="macro",
+        help="Path to python macro file."
+             "Any macros in this file will be parsed",
+        default=None
     )
 
     (options, args) = parser.parse_args()


### PR DESCRIPTION
Proposing this for issue #44. 

Basically I just execfile the path the user passes in on the command line or defines in the config file.

I believe this to be an acceptable solution. My editor reordered the imports... I can undo that if it's an issue, but I'm tired and want to sleep tonight ;)

Macro files can live anywhere, I put mine beside my presentation.md in macro.py for example 

macro.py:
```python
import re

from landslide.macro import Macro


class CalloutMacro(Macro):
    """Adds toggleable notes to slides"""

    def process(self, content, source=None):
        classes = []
        new_content = re.sub(r'<p>\.callout:\s?(.*?)</p>',
                             r'<p class="callout">\1</p>', content)

        if content != new_content:
            classes.append(u'has_callout')

        return new_content, classes
```