### PR TITLE
Fix character encoding problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The following markdown produces [this slideshow][sample].
 `python` and the following modules:
 
 - `jinja2`
+- `chardet`
 - `pygments` for code blocks syntax coloration
 
 #### Markup Conversion

--- a/landslide/main.py
+++ b/landslide/main.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
+import chardet
 
 from optparse import OptionParser
 
@@ -163,7 +164,12 @@ def run(input_file, options):
 def main():
     """Main program entry point"""
 
+    if sys.getdefaultencoding() != 'utf-8':
+        reload(sys)
+        sys.setdefaultencoding('utf-8')
+        
     options, input_file = _parse_options()
+    input_file = input_file.decode(chardet.detect(input_file).get('encoding'))
 
     if (options.debug):
         run(input_file, options)


### PR DESCRIPTION
[Issue 188](https://github.com/adamzap/landslide/issues/188): 
Error: 'ascii' codec can't decode byte 0xe7 in position 0: ordinal not in range(128)