### PR TITLE
Hotfix/markdown

### DIFF
--- a/landslide/parser.py
+++ b/landslide/parser.py
@@ -58,7 +58,10 @@ class Parser(object):
             if text.startswith(u'\ufeff'):  # check for unicode BOM
                 text = text[1:]
 
-            return markdown.markdown(text)
+            try:
+                return markdown.markdown(text, self.md_extensions)
+            except:
+                return markdown.markdown(text)
         elif self.format == 'restructuredtext':
             try:
                 from landslide.rst import html_body

--- a/landslide/parser.py
+++ b/landslide/parser.py
@@ -58,7 +58,7 @@ class Parser(object):
             if text.startswith(u'\ufeff'):  # check for unicode BOM
                 text = text[1:]
 
-            return markdown.markdown(text, self.md_extensions)
+            return markdown.markdown(text)
         elif self.format == 'restructuredtext':
             try:
                 from landslide.rst import html_body


### PR DESCRIPTION
in an environment with python 3.x the method

 return markdown.markdown(text, self.md_extensions)  doesn't accept the second paramer

fix it by wrapping it in a try/except

Thank you for this great project!
Antonio