### PR TITLE
Make compatible with Python-Markdown 3+

### DIFF
--- a/landslide/parser.py
+++ b/landslide/parser.py
@@ -58,7 +58,7 @@ class Parser(object):
             if text.startswith(u'\ufeff'):  # check for unicode BOM
                 text = text[1:]
 
-            return markdown.markdown(text, self.md_extensions)
+            return markdown.markdown(text, extensions=self.md_extensions)
         elif self.format == 'restructuredtext':
             try:
                 from landslide.rst import html_body


### PR DESCRIPTION
Starting from version 3.0, Python-Markdown will not support positional argument syntax anymore when calling the `markdown()` free function and `Markdown` constructor: https://python-markdown.github.io/change_log/release-3.0/#positional-arguments-deprecated .

A simple patch to use keyword syntax seems to be enough in order to make Landslide work with these newer versions.