### PR TITLE
Fix the prince CLI

### DIFF
--- a/landslide/generator.py
+++ b/landslide/generator.py
@@ -565,7 +565,7 @@ class Generator(object):
         dummy_fh = open(os.path.devnull, 'w')
 
         try:
-            command = ["prince", f.name, self.destination_file]
+            command = ["prince", f.name, "-o", self.destination_file]
 
             Popen(command, stderr=dummy_fh).communicate()
         except Exception:


### PR DESCRIPTION
This PR features the Prince command line fix suggested in #196 . With it, landslide can work with current versions of Prince.

Closes #196 
Closes #203