### PR TITLE
Use HTTPS URLs in generated HTML code

### DIFF
--- a/landslide/macro.py
+++ b/landslide/macro.py
@@ -164,7 +164,7 @@ class QRMacro(Macro):
         classes = []
 
         new_content = re.sub(r'<p>\.qr:\s?(\d*?)\|(.*?)</p>',
-                             r'<p class="qr"><img src="http://chart.apis.google.com/chart?chs=\1x\1&cht=qr&chl=\2&chf=bg,s,00000000&choe=UTF-8" alt="QR Code" /></p>',
+                             r'<p class="qr"><img src="https://chart.apis.google.com/chart?chs=\1x\1&cht=qr&chl=\2&chf=bg,s,00000000&choe=UTF-8" alt="QR Code" /></p>',
                              content)
 
         if content != new_content:

--- a/landslide/themes/default/base.html
+++ b/landslide/themes/default/base.html
@@ -71,7 +71,7 @@
           tex2jax: { inlineMath: [['$','$'],['\\(','\\)']] }
         });
       </script>
-      <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+      <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     {% endif %}
     <!-- /Javascripts -->
 </head>

--- a/landslide/themes/leapmotion/base.html
+++ b/landslide/themes/leapmotion/base.html
@@ -49,7 +49,7 @@
     {% endfor %}
     <!-- /Styles -->
     <!-- Javascripts -->
-    <script type="text/javascript" src="http://js.leapmotion.com/0.2.0-beta6/leap.min.js"></script>
+    <script type="text/javascript" src="https://js.leapmotion.com/0.2.0-beta6/leap.min.js"></script>
     {% if embed %}
     <script>
       {{ js.contents }}

--- a/landslide/themes/ribbon/base.html
+++ b/landslide/themes/ribbon/base.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <title>{{ head_title }}</title>
-    <link href='http://fonts.googleapis.com/css?family=PT+Sans|PT+Sans+Narrow|PT+Mono' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=PT+Sans|PT+Sans+Narrow|PT+Mono' rel='stylesheet' type='text/css'>
     <!-- Styles -->
     {% if embed %}
     <style type="text/css" media="print">


### PR DESCRIPTION
Use of HTTP resources in an HTTPS website is a security issue, since an
attacker that can masquerade as the unauthenticated HTTP server can also
inject pretty much everything into the HTTPS web page.

As a result, web browsers tend to frown upon, and will sometimes silently
block, such "mixed content".

To avoid problems when landslide-generated slides are served over HTTPS,
all links to third-party resources in landslide-generated code should
therefore use HTTPS.