### PR TITLE
Upgrade requirements and drop Python 2 support

### DIFF
--- a/landslide/generator.py
+++ b/landslide/generator.py
@@ -7,10 +7,9 @@ import inspect
 import jinja2
 import shutil
 import tempfile
+import configparser
 
 from subprocess import Popen
-from six import string_types
-from six.moves import configparser
 
 from . import utils
 from . import macro as macro_module
@@ -136,7 +135,7 @@ class Generator(object):
         """ Adds supplementary user css files to the presentation. The
             ``css_list`` arg can be either a ``list`` or a string.
         """
-        if isinstance(css_list, string_types):
+        if isinstance(css_list, str):
             css_list = [css_list]
 
         for css_path in css_list:
@@ -154,7 +153,7 @@ class Generator(object):
         """ Adds supplementary user javascript files to the presentation. The
             ``js_list`` arg can be either a ``list`` or a string.
         """
-        if isinstance(js_list, string_types):
+        if isinstance(js_list, str):
             js_list = [js_list]
         for js_path in js_list:
             if js_path and js_path not in self.user_js:

--- a/landslide/macro.py
+++ b/landslide/macro.py
@@ -2,9 +2,10 @@
 
 import os
 import re
-from six.moves import html_entities
-import pygments
 import sys
+import pygments
+import html.entities
+
 from . import utils
 
 from pygments.lexers import get_lexer_by_name
@@ -41,7 +42,7 @@ class CodeHighlightingMacro(Macro):
     def descape(self, string, defs=None):
         """Decodes html entities from a given string"""
         if defs is None:
-            defs = html_entities.entitydefs
+            defs = html.entities.entitydefs
         f = lambda m: defs[m.group(1)] if len(m.groups()) > 0 else m.group(0)
         return self.html_entity_re.sub(f, string)
 

--- a/landslide/parser.py
+++ b/landslide/parser.py
@@ -80,7 +80,7 @@ class Parser(object):
 
             text = text.replace('\n---\n', '\n<hr />\n')
 
-            return textile.textile(text, encoding=self.encoding)
+            return textile.textile(text, html_type='html5')
         else:
             raise NotImplementedError(u"Unsupported format %s, cannot parse"
                                       % self.format)

--- a/landslide/themes/default/css/screen.css
+++ b/landslide/themes/default/css/screen.css
@@ -550,7 +550,7 @@ aside {
 .vg { color: #19177C } /* Name.Variable.Global */
 .vi { color: #19177C } /* Name.Variable.Instance */
 .il { color: #666666 } /* Literal.Number.Integer.Long */
-.lineno { padding-right: 10px } /* A few space after linenos */
+.linenos { padding-right: 21px } /* A few space after linenos */
 
 #blank {
   position: absolute;

--- a/landslide/themes/leapmotion/css/screen.css
+++ b/landslide/themes/leapmotion/css/screen.css
@@ -549,7 +549,7 @@ aside {
 .vg { color: #19177C } /* Name.Variable.Global */
 .vi { color: #19177C } /* Name.Variable.Instance */
 .il { color: #666666 } /* Literal.Number.Integer.Long */
-.lineno { padding-right: 10px } /* A few space after linenos */
+.linenos { padding-right: 21px } /* A few space after linenos */
 
 #blank {
   position: absolute;

--- a/landslide/themes/light/css/screen.css
+++ b/landslide/themes/light/css/screen.css
@@ -452,7 +452,7 @@ body.expose .slide.current {
 .vg { color: #19177C } /* Name.Variable.Global */
 .vi { color: #19177C } /* Name.Variable.Instance */
 .il { color: #666666 } /* Literal.Number.Integer.Long */
-.lineno { padding-right: 10px } /* A few space after linenos */
+.linenos { padding-right: 21px } /* A few space after linenos */
 
 /* Presenter Mode */
 

--- a/landslide/themes/tango/css/screen.css
+++ b/landslide/themes/tango/css/screen.css
@@ -465,7 +465,7 @@ body.expose .slide.current {
 .vg { color: #19177C } /* Name.Variable.Global */
 .vi { color: #19177C } /* Name.Variable.Instance */
 .il { color: #666666 } /* Literal.Number.Integer.Long */
-.lineno { padding-right: 10px } /* A few space after linenos */
+.linenos { padding-right: 21px } /* A few space after linenos */
 
 /* Presenter Mode */
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-MarkupSafe==1.1.1
-Jinja2==2.10.1
-Markdown==2.6.11
-Pygments==2.2.0
-docutils==0.14
-six==1.11.0
+MarkupSafe==2.1.2
+Jinja2==3.1.2
+Markdown==3.4.1
+Pygments==2.14.0
+docutils==0.19

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,11 @@ setup(
         'textile'
     ],
     install_requires=[
-        'MarkupSafe==1.1.1',
-        'Jinja2==2.10.1',
-        'Markdown==2.6.11',
-        'Pygments==2.2.0',
-        'docutils==0.14',
-        'six==1.11.0'
+        'MarkupSafe==2.1.2',
+        'Jinja2==3.1.2',
+        'Markdown==3.4.1',
+        'Pygments==2.14.0',
+        'docutils==0.19'
     ],
     classifiers=[
         'Programming Language :: Python',


### PR DESCRIPTION
- Upgrade requirements to latest versions
- Update CI test versions through Python 3.11
- Remove `six`
- Update CSS for new `pygments` output
- Update `textile.textile` call for new signature